### PR TITLE
Enum Leakage Fix

### DIFF
--- a/palm/palmc/parse.py
+++ b/palm/palmc/parse.py
@@ -48,24 +48,24 @@ class ProtoProcessor(DispatchProcessor):
     def __init__(self):
         self.current_message = None
         self.messages = {}
-        self.enums = {}
+        self.message_enums = {}
         self.enum_sets = {}
         self.message_stack = []
         self.imports = set()
 
     def message(self, (tag, start, stop, subtags), buffer):
         if self.current_message:
-            self.message_stack.append((self.current_message, self.enums))
-        self.enums = {}
+            self.message_stack.append((self.current_message, self.message_enums))
+        self.message_enums = {}
 
         if subtags:
             dispatchList(self, subtags, buffer)
         cm = self.current_message
-        en = self.enums
+        en = self.message_enums
         self.enum_sets[cm] = en
 
         if self.message_stack:
-            self.current_message, self.enums = self.message_stack.pop()
+            self.current_message, self.message_enums = self.message_stack.pop()
             self.messages[self.current_message][1].append(cm)
         else:
             self.current_message = None
@@ -120,7 +120,10 @@ class ProtoProcessor(DispatchProcessor):
         name = res[0]
         rest = res[1:]
         fields = dict(rest)
-        self.enums[name] = fields
+        if self.current_message:
+            # Shove this enum into storage for the message that is
+            # currently being parsed.
+            self.message_enums[name] = fields
         return [name, fields]
 
     def enum_value(self, (tag, start, stop, subtags), buffer):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,31 @@
+from palm.palmc.parse import make_parser
+
+
+class ParserFixture(object):
+    src = ''
+
+    def setup(self):
+        parser = make_parser()
+        self.result = parser.parse(self.src)[1]
+
+class TestProperEnumOrder(ParserFixture):
+    src = '''\
+message Foo {
+    optional string bar = 1;
+}
+
+enum Baz {
+    ACK = 1;
+    NACK = 2;
+}
+'''
+    def test_enums_dont_nest_in_prior_objects(self):
+        msgname, (subs, fields, enums) = self.result[0]
+        assert 'Baz' not in enums
+
+    def test_top_level_enum_is_in_top_level_result(self):
+        ename, efields = self.result[1]
+        assert ename == 'Baz'
+        assert efields['ACK'] == 1
+        assert efields['NACK'] == 2
+


### PR DESCRIPTION
Test and fix for another enum leakage.

I would have just pushed to master but I wanted to make sure I understand what `self.enums` is in the parser. It seems to be a holding area for enums that belong to messages. Is that the case? If so then this commit pull request should be good. If not, then it probably works by sheer luck.

dowski
