### PR TITLE
Attempt to fix bumptech/palm#24

### DIFF
--- a/palm/palmc/codegen.py
+++ b/palm/palmc/codegen.py
@@ -44,7 +44,7 @@ def out(s):
     o.append(s)
 
 def clean(name):
-    return name.split('-', 1)[1]
+    return name.rsplit('-', 1)[1]
 
 def write_enum(name, spec):
     out(

--- a/palm/palmc/parse.py
+++ b/palm/palmc/parse.py
@@ -95,8 +95,11 @@ class ProtoProcessor(DispatchProcessor):
 
         return cm, self.messages[cm]
 
+    def _get_message_namespace(self):
+        return '-'.join(m[0] for m in self.message_stack)
+
     def message_label(self, (tag, start, stop, subtags), buffer):
-        self.current_message = str(len(self.message_stack)) + '-' +  buffer[start:stop]
+        self.current_message = self._get_message_namespace() + '-' + buffer[start:stop]
         if self.current_message in self.messages:
             raise ProtoParseError(start, stop, buffer, "message %s already defined" % self.current_message)
         self.messages[self.current_message] = {}, [] # fields, submessages


### PR DESCRIPTION
Messages were named using their stack _depth_ so 2 messages of the same
depth collided. This attempt names messages by their full scope -
avoiding collisions while hopefully not breaking other stuffs.
